### PR TITLE
fix: is_break flow and middleware order

### DIFF
--- a/lib/ferogram/src/flow.rs
+++ b/lib/ferogram/src/flow.rs
@@ -73,7 +73,7 @@ impl Flow {
     /// # }
     /// ```
     pub fn is_break(&self) -> bool {
-        matches!(self.action, Action::Continue)
+        matches!(self.action, Action::Break)
     }
 
     /// Checks if the current action is [`Action::Continue`].

--- a/lib/ferogram/src/router.rs
+++ b/lib/ferogram/src/router.rs
@@ -121,9 +121,9 @@ impl Router {
     ) -> Result<bool> {
         let mut middlewares = middlewares.extend(self.middlewares.clone());
 
-        for handler in self.handlers.iter_mut() {
-            let mut middleware_flow = middlewares.handle_before(client, update, injector).await;
-            if middleware_flow.is_continue() {
+        let mut middleware_flow = middlewares.handle_before(client, update, injector).await;
+        if middleware_flow.is_continue() {
+            for handler in self.handlers.iter_mut() {
                 let mut flow = handler.check(client, update).await;
                 flow.injector.extend(&mut middleware_flow.injector);
 


### PR DESCRIPTION
Hi. Thanks for your awesome library.
This PR has 2 commits. the first one is fixing the function `is_break` which was incorrectly checking if the action is continue.
the second commit makes it so that middlewares are only checked once per update. currently a middleware is run *per* handler.
Imagine if we have a middleware that checks if a user is a member of a channel and if not, it sends them a message to join. Currently this message will get sent multiple times because the middleware is ran for each handler. I don't see any reason for this since it doesn't depend on the handler anyways.